### PR TITLE
Fix Function generation bug on nested object type

### DIFF
--- a/codex/common/model.py
+++ b/codex/common/model.py
@@ -132,7 +132,7 @@ async def create_object_type(
         else:
             field_input["typeName"] = field.type
 
-        related_field = extract_field_type(field.type)
+        related_field = extract_field_type(field_input["typeName"])
         if related_field in available_objects:
             field_input["typeId"] = available_objects[related_field].id
 


### PR DESCRIPTION
ObjectFieldModel.type now can have two possible types (String & ObjectType), there is a bug where the `ObjectType` version ended up being handled as a string, this PR fixes it.