### PR TITLE
[AGPT-478] Remove ObjectFieldModel.type type checking

### DIFF
--- a/codex/common/model.py
+++ b/codex/common/model.py
@@ -156,21 +156,15 @@ async def create_object_type(
 
     field_inputs = []
     for field in object.Fields:
-        if isinstance(field.type, ObjectTypeModel):
-            available_objects = await create_object_type(field.type, available_objects)
-            type_name = field.type.name
-        else:
-            type_name = field.type
-
         field_inputs.append(
             {
                 "name": field.name,
                 "description": field.description,
-                "typeName": type_name,
+                "typeName": field.type,
                 "RelatedTypes": {
                     "connect": [
                         {"id": t.id}
-                        for t in get_related_types(type_name, available_objects)
+                        for t in get_related_types(field.type, available_objects)
                     ]
                 },
             }


### PR DESCRIPTION
This is a quick clean-up follow-up for:
https://github.com/Significant-Gravitas/codex/pull/84/files

Object.type is no longer polymorphic, removing silly checks.