### PR TITLE
[AGPT-489] Fix broken class compiling logic

### DIFF
--- a/codex/deploy/routes.py
+++ b/codex/deploy/routes.py
@@ -47,10 +47,18 @@ async def create_deployment(
                     ApiRouteSpec=APIRouteSpecArgsFromCompiledRouteRecursive2(
                         include=APIRouteSpecIncludeFromAPIRouteSpecRecursive3(
                             RequestObject=ObjectTypeArgsFromAPIRouteSpecRecursive4(
-                                **{"include": {"Fields": True}}
+                                **{
+                                    "include": {
+                                        "Fields": {"include": {"RelatedTypes": True}}
+                                    }
+                                }
                             ),
                             ResponseObject=ObjectTypeArgsFromAPIRouteSpecRecursive4(
-                                **{"include": {"Fields": True}}
+                                **{
+                                    "include": {
+                                        "Fields": {"include": {"RelatedTypes": True}}
+                                    }
+                                }
                             ),
                         )
                     ),

--- a/codex/develop/agent.py
+++ b/codex/develop/agent.py
@@ -129,20 +129,27 @@ async def develop_route(
     if depth >= RECURSION_DEPTH_LIMIT:
         raise ValueError("Recursion depth exceeded")
 
+    function_include = {
+        "include": {
+            "FunctionArgs": {
+                "include": {"RelatedTypes": {"include": {"Fields": True}}}
+            },
+            "FunctionReturn": {
+                "include": {"RelatedTypes": {"include": {"Fields": True}}}
+            },
+        }
+    }
+
     compiled_route = await CompiledRoute.prisma().find_unique_or_raise(
         where={"id": compiled_route_id},
         include={
-            "Functions": {
-                "include": {
-                    "FunctionArgs": {"include": {"RelatedTypes": True}},
-                    "FunctionReturn": {"include": {"RelatedTypes": True}},
-                }
-            }
+            "RootFunction": function_include,
+            "Functions": function_include,
         },
     )
     generated_func = {}
     generated_objs = {}
-    for func in compiled_route.Functions:
+    for func in compiled_route.Functions + [compiled_route.RootFunction]:
         if func.functionName != function.functionName:
             generated_func[func.functionName] = func
 

--- a/codex/tests/compile_test.py
+++ b/codex/tests/compile_test.py
@@ -8,7 +8,7 @@ from codex.develop.compile import extract_path_params, get_object_type_deps
 
 
 async def process_object_type(obj: ObjectType) -> str:
-    objects = await get_object_type_deps(obj, set()) + [obj]
+    objects = await get_object_type_deps(obj, set())
     return "\n\n".join([generate_object_template(v) for v in objects])
 
 


### PR DESCRIPTION
The cause of https://linear.app/autogpt/issue/AGPT-489 is a broken class dependency compiling logic where the class ended up not being included in the code.

The scope of this PR is making the logic work (tested by the existing integration tests and manually verifying the result on the DB).

Out of scope:
* Adding code validation on non-existing classes (should be covered by static code analysis: https://github.com/Significant-Gravitas/codex/pull/71)
* More testing covering this error scenario (I just don't have any time yet to add it)