### PR TITLE
fix(common): Fix error state handling in `execute_command`

### DIFF
--- a/codex/common/exec_external_tool.py
+++ b/codex/common/exec_external_tool.py
@@ -166,4 +166,4 @@ async def execute_command(
     if raise_on_error:
         raise ValidationError((stderr or stdout).decode("utf-8"))
     else:
-        return stderr.decode("utf-8")
+        return (stderr or stdout).decode("utf-8")


### PR DESCRIPTION
By extension, this fixes code validation by raising an error when the process (e.g. `pip install`) exits with a non-zero status.