### PR TITLE
fix(compile): Resolve multiplicate dependencies -> fix static code analysis

### DIFF
--- a/codex/develop/compile.py
+++ b/codex/develop/compile.py
@@ -4,6 +4,7 @@ import re
 from datetime import datetime
 from typing import List, Set
 
+from packaging import version
 from prisma.models import (
     CompiledRoute,
     CompletedApp,
@@ -544,6 +545,16 @@ app = FastAPI(title="{name}", lifespan=lifespan, description='''{desc}''')
         )
 
         service_routes_code.append(create_server_route_code(compiled_route))
+
+    # Resolve multiplicate packages to highest specified version
+    resolved_packages: dict[str, Package] = {}
+    for package in packages:
+        name = package.packageName
+        if name not in resolved_packages or version.parse(
+            package.version
+        ) > version.parse(resolved_packages[name].version):
+            resolved_packages[name] = package
+    packages = list(resolved_packages.values())
 
     # Compile the server code
     server_code = "\n".join(server_code_imports)


### PR DESCRIPTION
- Move resolution of multiplicate dependencies from deploy to compile
- Rename `generate_requirements_txt` to `requirements_txt_from_packages`