### PR TITLE
fix(compile): Fix package requirements resolution

### DIFF
--- a/codex/develop/compile.py
+++ b/codex/develop/compile.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 
 from codex.api_model import Identifiers
 from codex.common.database import INCLUDE_FIELD, INCLUDE_FUNC
+from codex.common.exec_external_tool import DEFAULT_DEPS
 from codex.common.types import normalize_type
 from codex.deploy.model import Application
 from codex.develop.code_validation import CodeValidator
@@ -546,15 +547,7 @@ app = FastAPI(title="{name}", lifespan=lifespan, description='''{desc}''')
 
         service_routes_code.append(create_server_route_code(compiled_route))
 
-    # Resolve multiplicate packages to highest specified version
-    resolved_packages: dict[str, Package] = {}
-    for package in packages:
-        name = package.packageName
-        if name not in resolved_packages or version.parse(
-            package.version
-        ) > version.parse(resolved_packages[name].version):
-            resolved_packages[name] = package
-    packages = list(resolved_packages.values())
+    packages = resolve_package_requirements(packages)
 
     # Compile the server code
     server_code = "\n".join(server_code_imports)
@@ -590,3 +583,29 @@ app = FastAPI(title="{name}", lifespan=lifespan, description='''{desc}''')
         completed_app=completed_app,
         packages=packages,
     )
+
+
+def resolve_package_requirements(packages: list[Package]) -> list[Package]:
+    """
+    Resolve duplicates and version conflicts in a list of package requirements.
+
+    - Resolves multiple requirements for the same package to the highest specified version
+    - Resolves requirements that match an entry of `DEFAULT_DEPS` to the hardcoded entry
+    """
+    resolved_packages: dict[str, Package] = {}
+    for package in packages:
+        name = package.packageName
+        if (
+            package.id == name
+            and name in DEFAULT_DEPS
+            or (
+                name not in resolved_packages
+                or not resolved_packages[name].version
+                or package.version
+                and version.parse(package.version)
+                > version.parse(resolved_packages[name].version)
+            )
+            and name not in DEFAULT_DEPS
+        ):
+            resolved_packages[name] = package
+    return list(resolved_packages.values())


### PR DESCRIPTION
* The hardcoded `DEFAULT_DEPS` dependencies `fastapi`, `pydantic`, `uvicorn`, and `prisma` need special treatment,
  because if they are included in the `packages` of a generated function,
  those requirements are not scrutinized during code validation, allowing invalid versions.

* `version.parse(..)` raises an error when given an empty string. `package.version` is not required, so the case of `not package.version` must be checked before trying to parse it.