### PR TITLE
installing version 2.28.0 of git to make use of initial-branch flag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,14 @@ WORKDIR /app
 
 # Install system dependencies
 RUN apt-get update \
-    && apt-get install -y build-essential curl ffmpeg git \
+    && apt-get install -y build-essential curl ffmpeg wget libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && wget https://github.com/git/git/archive/v2.28.0.tar.gz -O git.tar.gz \
+    && tar -zxf git.tar.gz \
+    && cd git-* \
+    && make prefix=/usr all \
+    && make prefix=/usr install
 
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
 ENV POETRY_VERSION=1.1.8 \


### PR DESCRIPTION
Installing version 2.28.0 of git to make use of initial-branch flag. This is needed so the locally created branch is the same as remote branch (main). Having the same branches means we don't need to do the master:main mapping when doing a first push to a new repo. While this works on cloudrun, depending on local git config settings, it was failing locally for engineers. It's also cleaner.