### PR TITLE
adding git author in the initial commit

### DIFF
--- a/codex/deploy/packager.py
+++ b/codex/deploy/packager.py
@@ -500,7 +500,7 @@ def git_init(app_dir: Path) -> Repo:
         )
 
         repo.git.add(".")
-        repo.index.commit("Initial commit", author=author)
+        repo.index.commit("Initial commit", author=author, committer=author)
 
         logger.info("Git repository initialized and all files committed")
         return repo


### PR DESCRIPTION
Currently initial commit is coming as 'root' in the repos created by codex. We want to ensure the correct username is used. So adding an author to the initial commit. 