### PR TITLE
[AGPT-686] Making fields not Optional

### DIFF
--- a/codex/common/model.py
+++ b/codex/common/model.py
@@ -20,9 +20,7 @@ class ObjectTypeModel(BaseModel):
     description: Optional[str] = Field(
         description="The description of the object", default=None
     )
-    Fields: List["ObjectFieldModel"] = Field(
-        description="The fields of the object"
-    )
+    Fields: List["ObjectFieldModel"] = Field(description="The fields of the object")
     is_pydantic: bool = Field(
         description="Whether the object is a pydantic model", default=True
     )


### PR DESCRIPTION
We've been getting this error:

AssertionError: Fields should be an array

It's because the pydantic validation is passing because Fields was marked as optional. This PR changes that. 