### PR TITLE
kill process on 8080

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Clean up
       if: always()
       run: |
-        lsof -ti:8080 | xargs kill -9
+        lsof -ti:8080 | grep LISTEN | xargs --no-run-if-empty kill -9
         docker stop codex
         docker rm codex
     env:


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a command to forcefully terminate any process occupying port 8080 during the cleanup phase of the GitHub Actions workflow. This ensures that the port is free for subsequent runs, potentially avoiding conflicts or errors.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benchmarks.yml</strong><dd><code>Add process termination on port 8080 to GitHub Actions cleanup</code></dd></summary>
<hr>
      
.github/workflows/benchmarks.yml

<li>Added a command to kill any process running on port 8080 in the <br>cleanup step of the GitHub Actions workflow.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/codex/pull/254/files#diff-22eef62c9d7b36d02f5fd5aaada92702e22d6795c464239cb7b8fe0f26ea1e1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

