### PR TITLE
fix port mapping

### DIFF
--- a/codex/deploy/packager.py
+++ b/codex/deploy/packager.py
@@ -237,7 +237,7 @@ services:
             timeout: 5s
             retries: 5
         ports:
-            - "${DB_PORT}:5432"
+            - "${DB_PORT:-5432}:5432"
     app:
         build:
             context: .


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Added port mapping for the database service in the Docker Compose file to ensure external access to the database using the environment variable `DB_PORT`.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>packager.py</strong><dd><code>Add Database Port Mapping to Docker Compose Generator</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
codex/deploy/packager.py

<li>Added port mapping for the database service in the generated Docker <br>Compose file.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/codex/pull/259/files#diff-f73ea915599228d212802db5eca6bbb3de83068df88de2fe7c9d5b86dfe985f5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

