### PR TITLE
Simple prompt changes to help interview

### DIFF
--- a/codex/prompts/gpt-4o/interview/module/system.j2
+++ b/codex/prompts/gpt-4o/interview/module/system.j2
@@ -4,8 +4,9 @@ Respond in the following json format:
 
 {{ format_instructions }}
 
-phase_completed is only true when the user request the next phase, "Thats Great", "Okay", "Make it", "Design it" etc.
-If phase is completed, do not output the modules list
+Detect if the user is happy and wants to move on to the next phase. 
+Set `phase_completed` to true only when the user explicitly requests the app to be built, created, or states satisfaction with the current features. 
+If `phase_completed` is true, do not include the modules list in your response.
 
 When adding what you are going to say. Please speak in a friendly manner and consiesly and always talk in singular first person, for example: "I've".
 When responding to the user, speak with simple words and keep it short!

--- a/codex/prompts/gpt-4o/interview/understand/system.j2
+++ b/codex/prompts/gpt-4o/interview/understand/system.j2
@@ -4,9 +4,9 @@ Respond in the following json format:
 
 {{ format_instructions }}
 
-
-phase_completed is only true when the user request the app is built or created.
-If phase is completed, do not output the features list
+Detect if the user is happy and wants to move on to the next phase. 
+Set `phase_completed` to true only when the user explicitly requests the app to be built, created, or states satisfaction with the current features. 
+If `phase_completed` is true, do not include the modules list in your response.
 
 When adding what you are going to say. Please speak in a friendly manner and consiesly and always talk in singular first person, for example: "I've".
 When responding to the user, speak with simple words and keep it short!

--- a/codex/prompts/gpt-4o/interview/update/system.j2
+++ b/codex/prompts/gpt-4o/interview/update/system.j2
@@ -5,8 +5,9 @@ Respond in the following json format:
 {{ format_instructions }}
 
 
-phase_completed is only true when the user request the next phase, "Thats Great", "Okay", "Make it", "Design it" etc.
-If phase is completed, do not output the features list
+Detect if the user is happy and wants to move on to the next phase. 
+Set `phase_completed` to true only when the user explicitly requests the app to be built, created, or states satisfaction with the current features. 
+If `phase_completed` is true, do not include the features list in your response.
 
 When adding what you are going to say. Please speak in a friendly manner and consiesly and always talk in singular first person, for example: "I've".
 When responding to the user, speak with simple words and keep it short!


### PR DESCRIPTION
### **User description**
These prompt changes seem to help it properly understand when the user is happy and wants to continue

![image](https://github.com/Significant-Gravitas/codex/assets/27962737/f92aeb28-a5fd-49a7-a348-05ea2629544c)
![image](https://github.com/Significant-Gravitas/codex/assets/27962737/c0ab5cea-ea7d-4c88-a057-34b72f7571b7)


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the detection of user satisfaction to determine phase completion.
- Clarified the conditions for setting `phase_completed` to true across multiple prompt files.
- Updated instructions to exclude modules or features list when `phase_completed` is true.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system.j2</strong><dd><code>Improve phase completion detection and response clarity</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
codex/prompts/gpt-4o/interview/module/system.j2

<li>Updated instructions to detect user satisfaction for phase completion.<br> <li> Clarified conditions for setting <code>phase_completed</code> to true.<br> <li> Specified not to include modules list if <code>phase_completed</code> is true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/codex/pull/276/files#diff-8cdbffe7c7dddf301de1252d9605827bd1ef9c7ea531833ec110d90fdaa917e2">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>system.j2</strong><dd><code>Improve phase completion detection and response clarity</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
codex/prompts/gpt-4o/interview/understand/system.j2

<li>Updated instructions to detect user satisfaction for phase completion.<br> <li> Clarified conditions for setting <code>phase_completed</code> to true.<br> <li> Specified not to include modules list if <code>phase_completed</code> is true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/codex/pull/276/files#diff-eb0c920bcbde011be097ac0333abed4af39e063c6988d7a03ef1806237eed426">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>system.j2</strong><dd><code>Improve phase completion detection and response clarity</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
codex/prompts/gpt-4o/interview/update/system.j2

<li>Updated instructions to detect user satisfaction for phase completion.<br> <li> Clarified conditions for setting <code>phase_completed</code> to true.<br> <li> Specified not to include features list if <code>phase_completed</code> is true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/codex/pull/276/files#diff-6de3c7caaa14a63c37a1e2531d8e4cd7f135ca0edea996bf92fd2a20b2ece291">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

